### PR TITLE
Render manpages asynchronously using a `ThreadPoolExecutor`

### DIFF
--- a/src/tldr_man/pages.py
+++ b/src/tldr_man/pages.py
@@ -149,7 +149,7 @@ def update_cache() -> None:
 
                         # Render and save a manpage from the tldr-page.
                         manpage = render_manpage(page.read_text())
-                        res_file = res_dir / (page.name.removesuffix('.md') + '.1')
+                        res_file = res_dir / (page.name.removesuffix('.md') + '.' + TLDR_MANPAGE_SECTION)
                         res_file.write_text(manpage)
 
         # Now that the updated cache has been generated, remove the old cache, make sure the parent directory exists,
@@ -240,7 +240,7 @@ def display_page(page: Path) -> None:
 
 def find_page(page_name: str, /, locales: Iterable[str], page_sections: Iterable[str]) -> Optional[Path]:
     for search_dir in get_dir_search_order(locales, page_sections):
-        page = search_dir / (page_name + '.1')
+        page = search_dir / (page_name + '.' + TLDR_MANPAGE_SECTION)
 
         if page.exists():
             return page


### PR DESCRIPTION
These changes significantly improve the speed of `update_cache()` by having calls to `render_manpage()` run in parallel (using `concurrent.futures.ThreadPoolExecutor`).

This causes a significant time improvement in `tldr --update` for the user.

On my machine with 12 logical cpu cores (6 physical cpu cores), `ThreadPoolExecutor` will launch 16 threads (using the calculation `(os.cpu_count() or 1) + 4`). This results in the following time improvements:

```
new_tldr -u  268.20s user 410.43s system 646% cpu 1:44.98 total
old_tldr -u  190.29s user 215.99s system  81% cpu 8:20.22 total
```

This means a cache update now runs 476.49% faster. 