### PR TITLE
CLI improvements

### DIFF
--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -134,7 +134,7 @@ def subcommand_version(_ctx):
     print(TLDR_COMMAND_NAME, __version__)
 
 
-@click.command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green')
+@click.command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)
 @click.argument('page', nargs=-1, required=True)
 @click.option('-p', '--platform',
               metavar='PLATFORM',

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -157,7 +157,7 @@ def subcommand_version(_ctx):
               callback=subcommand_list, expose_value=False,
               is_flag=True,
               help='List all the pages for the current platform')
-@click.option('--manpath',
+@click.option('-M', '--manpath',
               callback=subcommand_manpath, expose_value=False,
               is_flag=True,
               help='Print the paths to the tldr manpages')

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -121,7 +121,7 @@ def subcommand_list(locales, page_sections):
 @standalone_subcommand
 @require_tldr_cache
 def subcommand_manpath(locales, page_sections):
-    print(':'.join(unique(str(x.parent) for x in pages.get_dir_search_order(locales, page_sections))))
+    print(':'.join(unique(str(man_dir.parent) for man_dir in pages.get_dir_search_order(locales, page_sections))))
 
 
 @command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -137,10 +137,12 @@ def subcommand_version(_ctx):
 @click.command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green')
 @click.argument('page', nargs=-1, required=True)
 @click.option('-p', '--platform',
+              metavar='PLATFORM',
               type=click.Choice(TLDR_PLATFORMS),
               is_eager=True,
               help='Override the preferred platform')
 @click.option('-L', '--language',
+              metavar='LANGUAGE',
               is_eager=True,
               help='Specify a preferred language')
 @click.option('-u', '--update',

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -23,8 +23,6 @@ Run `tldr --help` for more information,
 or visit the project repository at https://github.com/superatomic/tldr-man-client.
 """
 
-from importlib import metadata
-__version__ = metadata.version('tldr-man')
 __author__ = "Olivia Kinnear <contact@superatomic.dev>"
 
 from pathlib import Path
@@ -40,9 +38,6 @@ from tldr_man import pages
 from tldr_man.languages import get_locales
 from tldr_man.platforms import get_page_sections, TLDR_PLATFORMS
 from tldr_man.util import unique, mkstemp_path
-
-
-TLDR_COMMAND_NAME = 'tldr'
 
 
 def standalone_subcommand(func):
@@ -129,11 +124,6 @@ def subcommand_manpath(locales, page_sections):
     print(':'.join(unique(str(x.parent) for x in pages.get_dir_search_order(locales, page_sections))))
 
 
-@standalone_subcommand
-def subcommand_version(_ctx):
-    print(TLDR_COMMAND_NAME, __version__)
-
-
 @click.command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)
 @click.argument('page', nargs=-1, required=True)
 @click.option('-p', '--platform',
@@ -163,11 +153,9 @@ def subcommand_version(_ctx):
               callback=subcommand_manpath, expose_value=False,
               is_flag=True,
               help='Print the paths to the tldr manpages')
-@click.option('-v', '-V', '--version',
-              callback=subcommand_version, expose_value=False,
-              is_flag=True,
-              is_eager=True,
-              help='Display the version of the client')
+@click.version_option(None, '-v', '-V', '--version',
+                      message="%(prog)s %(version)s",
+                      help='Display the version and exit.')
 @click.help_option('-h', '--help')
 @click.pass_context
 @require_tldr_cache

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -155,8 +155,9 @@ def subcommand_manpath(locales, page_sections):
         help='Print the paths to the tldr manpages')
 @version_option(None, '-v', '-V', '--version',
                 message="%(prog)s %(version)s",
-                help='Display the version and exit.')
-@help_option('-h', '--help')
+                help='Display the version and exit')
+@help_option('-h', '--help',
+             help='Show this message and exit')
 @pass_context
 @require_tldr_cache
 def cli(locales, page_sections, page: list[str], **_):

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -175,10 +175,10 @@ def cli(locales, page_sections, page: list[str], **_):
     """TLDR client that displays tldr-pages as manpages"""
     page_name = '-'.join(page).strip().lower()
 
-    page = pages.find_page(page_name, locales, page_sections)
+    page_path = pages.find_page(page_name, locales, page_sections)
 
-    if page is not None:
-        pages.display_page(page)
+    if page_path is not None:
+        pages.display_page(page_path)
 
 
 if __name__ == '__main__':

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -31,7 +31,7 @@ from os import remove
 from functools import wraps
 
 import click
-from click import Context
+from click import Context, command, argument, option, version_option, help_option, pass_context
 from click_help_colors import HelpColorsCommand
 
 from tldr_man import pages
@@ -124,40 +124,40 @@ def subcommand_manpath(locales, page_sections):
     print(':'.join(unique(str(x.parent) for x in pages.get_dir_search_order(locales, page_sections))))
 
 
-@click.command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)
-@click.argument('page', nargs=-1, required=True)
-@click.option('-p', '--platform',
-              metavar='PLATFORM',
-              type=click.Choice(TLDR_PLATFORMS),
-              is_eager=True,
-              help='Override the preferred platform')
-@click.option('-L', '--language',
-              metavar='LANGUAGE',
-              is_eager=True,
-              help='Specify a preferred language')
-@click.option('-u', '--update',
-              callback=subcommand_update, expose_value=False,
-              is_flag=True,
-              is_eager=True,
-              help='Update the tldr-pages cache')
-@click.option('-r', '--render',
-              callback=subcommand_render, expose_value=False,
-              type=click.Path(exists=True, dir_okay=False, path_type=Path), nargs=1,
-              is_eager=True,
-              help='Render a page locally')
-@click.option('-l', '--list',
-              callback=subcommand_list, expose_value=False,
-              is_flag=True,
-              help='List all the pages for the current platform')
-@click.option('-M', '--manpath',
-              callback=subcommand_manpath, expose_value=False,
-              is_flag=True,
-              help='Print the paths to the tldr manpages')
-@click.version_option(None, '-v', '-V', '--version',
-                      message="%(prog)s %(version)s",
-                      help='Display the version and exit.')
-@click.help_option('-h', '--help')
-@click.pass_context
+@command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)
+@argument('page', nargs=-1, required=True)
+@option('-p', '--platform',
+        metavar='PLATFORM',
+        type=click.Choice(TLDR_PLATFORMS),
+        is_eager=True,
+        help='Override the preferred platform')
+@option('-L', '--language',
+        metavar='LANGUAGE',
+        is_eager=True,
+        help='Specify a preferred language')
+@option('-u', '--update',
+        callback=subcommand_update, expose_value=False,
+        is_flag=True,
+        is_eager=True,
+        help='Update the tldr-pages cache')
+@option('-r', '--render',
+        callback=subcommand_render, expose_value=False,
+        type=click.Path(exists=True, dir_okay=False, path_type=Path), nargs=1,
+        is_eager=True,
+        help='Render a page locally')
+@option('-l', '--list',
+        callback=subcommand_list, expose_value=False,
+        is_flag=True,
+        help='List all the pages for the current platform')
+@option('-M', '--manpath',
+        callback=subcommand_manpath, expose_value=False,
+        is_flag=True,
+        help='Print the paths to the tldr manpages')
+@version_option(None, '-v', '-V', '--version',
+                message="%(prog)s %(version)s",
+                help='Display the version and exit.')
+@help_option('-h', '--help')
+@pass_context
 @require_tldr_cache
 def cli(locales, page_sections, page: list[str], **_):
     """TLDR client that displays tldr-pages as manpages"""


### PR DESCRIPTION
Changes:
- Adds `-M` as an alias for `--manpath`.
- Adds metavars for the `--platform` and `--language` options.
- `tldr` will now show command usage (`tldr --help`) when no arguments or options are specified.
- Removes the trailing period from the end of the description for the `--help` option.
- Refactoring.