### PR TITLE
Add shell completion for page names and the `--language` option

### DIFF
--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -35,6 +35,7 @@ from click import Context, command, argument, option, version_option, help_optio
 from click_help_colors import HelpColorsCommand
 
 from tldr_man import pages
+from tldr_man.shell_completion import page_shell_complete, language_shell_complete
 from tldr_man.languages import get_locales
 from tldr_man.platforms import get_page_sections, TLDR_PLATFORMS
 from tldr_man.util import unique, mkstemp_path
@@ -125,7 +126,7 @@ def subcommand_manpath(locales, page_sections):
 
 
 @command(cls=HelpColorsCommand, help_headers_color='yellow', help_options_color='green', no_args_is_help=True)
-@argument('page', nargs=-1, required=True)
+@argument('page', nargs=-1, required=True, shell_complete=page_shell_complete)
 @option('-p', '--platform',
         metavar='PLATFORM',
         type=click.Choice(TLDR_PLATFORMS),
@@ -134,6 +135,7 @@ def subcommand_manpath(locales, page_sections):
 @option('-L', '--language',
         metavar='LANGUAGE',
         is_eager=True,
+        shell_complete=language_shell_complete,
         help='Specify a preferred language')
 @option('-u', '--update',
         callback=subcommand_update, expose_value=False,

--- a/src/tldr_man/shell_completion.py
+++ b/src/tldr_man/shell_completion.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Olivia Kinnear
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rich shell completions for the client."""
+
+from click import Context, Parameter
+from click.shell_completion import CompletionItem
+
+from tldr_man.pages import TLDR_CACHE_HOME, get_dir_search_order
+from tldr_man.languages import get_locales, all_language_codes
+from tldr_man.platforms import get_page_sections
+
+
+def page_shell_complete(ctx: Context, param: Parameter, incomplete: str) -> list[CompletionItem]:
+    if not TLDR_CACHE_HOME.exists() or param.name is None: # the `param.name is None` check makes the type checker happy
+        return []
+
+    locales: list[str] = get_locales(ctx)
+    page_sections: list[str] = get_page_sections(ctx)
+
+    completed_part = ''.join([part + '-' for part in ctx.params[param.name] or []])
+
+    return [
+        CompletionItem(page.stem.removeprefix(completed_part))
+        for section in get_dir_search_order(locales, page_sections)
+        for page in section.iterdir()
+        if page.is_file()
+        if page.stem.startswith(completed_part + incomplete)
+    ]
+
+
+def language_shell_complete(_ctx: Context, _param: Parameter, _incomplete: str) -> list[CompletionItem]:
+    if not TLDR_CACHE_HOME.exists():
+        return []
+    return [CompletionItem(code) for code in all_language_codes()]


### PR DESCRIPTION
Adds [click shell completion](https://click.palletsprojects.com/en/8.1.x/shell-completion/) for page names and the `--language` option.