### PR TITLE
Improve display of the `--update` command

### DIFF
--- a/src/tldr_man/pages.py
+++ b/src/tldr_man/pages.py
@@ -141,7 +141,7 @@ def update_cache() -> None:
                 # `render_manpage()` takes a significant amount of time to run.
                 # Due to the number of pages that need to be rendered,
                 # this function is invoked simultaneously using threads.
-                def to_manpage(tldr_page: zipfile.Path) -> (str, str):
+                def to_manpage(tldr_page: zipfile.Path) -> tuple[str, str]:
                     """Convert a tldr-page into a manpage"""
                     rendered_manpage = render_manpage(tldr_page.read_text())
                     manpage_filename = tldr_page.name.removesuffix('.md') + '.' + TLDR_MANPAGE_SECTION

--- a/src/tldr_man/pages.py
+++ b/src/tldr_man/pages.py
@@ -135,7 +135,7 @@ def update_cache() -> None:
                 res_dir.mkdir(parents=True, exist_ok=True)  # Create the directories if they don't exist.
 
                 # Create the label for the progress bars that are shown.
-                progressbar_label = (style(f'{language_dir.name:11s}', fg='blue')
+                progressbar_label = (style(f"{language_directory_to_code(language_dir):5s}", fg='blue')
                                      + ' / '
                                      + style(f'{sections_dir.name:7s}', fg='blue'))
 

--- a/src/tldr_man/pages.py
+++ b/src/tldr_man/pages.py
@@ -129,7 +129,6 @@ def update_cache() -> None:
             if not language_dir.is_dir():
                 continue
             for sections_dir in language_dir.iterdir():
-
                 # Get the full path to the directory where all manpages for this language and section will be extracted.
                 res_dir = tldr_temp_dir / language_dir.name / sections_dir.name / ('man' + TLDR_MANPAGE_SECTION)
                 res_dir.mkdir(parents=True, exist_ok=True)  # Create the directories if they don't exist.
@@ -181,11 +180,10 @@ def update_cache() -> None:
             rmtree(TLDR_CACHE_HOME)
 
         makedirs(TLDR_CACHE_HOME.parent, exist_ok=True)
-
         move(tldr_temp_dir, TLDR_CACHE_HOME)
+
     finally:
         # Clean up any temporary files that aren't gone.
-
         with suppress(NameError, FileNotFoundError):
             # noinspection PyUnboundLocalVariable
             remove(tldr_zip_archive)


### PR DESCRIPTION
Changes:
- Shortens the label on the cache update progressbar.
- Displays the number of added, updated, and unchanged pages after updating.
- Refactoring.