### PR TITLE
Patch click Bash completion generation

### DIFF
--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -35,10 +35,13 @@ from click import Context, command, argument, option, version_option, help_optio
 from click_help_colors import HelpColorsCommand
 
 from tldr_man import pages
-from tldr_man.shell_completion import page_shell_complete, language_shell_complete
+from tldr_man.shell_completion import page_shell_complete, language_shell_complete, patch_bash_completion
 from tldr_man.languages import get_locales
 from tldr_man.platforms import get_page_sections, TLDR_PLATFORMS
 from tldr_man.util import unique, mkstemp_path
+
+
+patch_bash_completion()  # See issue #10
 
 
 def standalone_subcommand(func):

--- a/src/tldr_man/shell_completion.py
+++ b/src/tldr_man/shell_completion.py
@@ -15,7 +15,7 @@
 """Rich shell completions for the client."""
 
 from click import Context, Parameter
-from click.shell_completion import CompletionItem
+from click.shell_completion import CompletionItem, BashComplete
 
 from tldr_man.pages import CACHE_DIR, get_dir_search_order
 from tldr_man.languages import get_locales, all_language_codes
@@ -44,3 +44,12 @@ def language_shell_complete(_ctx: Context, _param: Parameter, _incomplete: str) 
     if not CACHE_DIR.exists():
         return []
     return [CompletionItem(code) for code in all_language_codes()]
+
+
+def patch_bash_completion():
+    """
+    Patches click Bash shell completion generation to not raise an error on generating for Bash versions older than 4.4.
+
+    Fixes <https://github.com/superatomic/tldr-man/issues/10>, <https://github.com/pallets/click/issues/2574>.
+    """
+    BashComplete._check_version = lambda: None


### PR DESCRIPTION
Fix for #10. This patch can be removed once https://github.com/pallets/click/issues/2574 is fixed.