### PR TITLE
Fix broken bash shell completion

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,13 +97,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.3"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
-    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]
@@ -189,4 +189,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.4"
-content-hash = "d42533b3fd33f7d1bc87bc5b0d9542972cf1eba2b5934e32a93dfb88a2e2a88e"
+content-hash = "b257f5894d9f4e6f1d1cda12f78fbb9a53e84d3c11e7d4ffb6098b3ec8ff4ad0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ include = ["generate_completions.sh", "tldr-man.1"]
 
 [tool.poetry.dependencies]
 python = "^3.10.4"
-click = "^8.1.3"
+click = "^8.1.7"
 click-help-colors = "^0.9.1"
 requests = "^2.28.1"
 

--- a/src/tldr_man/main.py
+++ b/src/tldr_man/main.py
@@ -35,13 +35,10 @@ from click import Context, command, argument, option, version_option, help_optio
 from click_help_colors import HelpColorsCommand
 
 from tldr_man import pages
-from tldr_man.shell_completion import page_shell_complete, language_shell_complete, patch_bash_completion
+from tldr_man.shell_completion import page_shell_complete, language_shell_complete
 from tldr_man.languages import get_locales
 from tldr_man.platforms import get_page_sections, TLDR_PLATFORMS
 from tldr_man.util import unique, mkstemp_path
-
-
-patch_bash_completion()  # See issue #10
 
 
 def standalone_subcommand(func):

--- a/src/tldr_man/shell_completion.py
+++ b/src/tldr_man/shell_completion.py
@@ -44,12 +44,3 @@ def language_shell_complete(_ctx: Context, _param: Parameter, _incomplete: str) 
     if not CACHE_DIR.exists():
         return []
     return [CompletionItem(code) for code in all_language_codes()]
-
-
-def patch_bash_completion():
-    """
-    Patches click Bash shell completion generation to not raise an error on generating for Bash versions older than 4.4.
-
-    Fixes <https://github.com/superatomic/tldr-man/issues/10>, <https://github.com/pallets/click/issues/2574>.
-    """
-    BashComplete._check_version = lambda _: None


### PR DESCRIPTION
Fixes #10 by bumping the minimum Click version to `^8.1.7`.
Reverts changes introduced in #11 which patched this bug previously.